### PR TITLE
Lift restriction of carrierwave < 0.11

### DIFF
--- a/carrierwave-crop.gemspec
+++ b/carrierwave-crop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 3.2"
-  spec.add_dependency "carrierwave", [">= 0.8.0", "< 0.11.0"]
+  spec.add_dependency "carrierwave", ">= 0.8.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
I don't see why this was ever necessary in the first place, I just tested it with the lastest `carrierwave@2.2.0` and it still works like a charm.